### PR TITLE
fix: display client_waiting_connections instead of free_clients

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -1819,7 +1819,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "free pgbouncer connection slots"
+              "options": "pgbouncer client connections waiting"
             },
             "properties": [
               {
@@ -1885,12 +1885,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "pgbouncer_free_clients{Name=\"prod-1-$project\"}",
+          "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{Name=\"prod-1-$project\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "free pgbouncer connection slots",
+          "legendFormat": "pgbouncer client connections waiting",
           "refId": "D",
           "step": 240
         }


### PR DESCRIPTION
* Turns out pgbouncer actively increases its `free_clients` stat as connection slots are being used, thus it isn't really useful
* `client_waiting_connections` can help track issues where pgbouncer config optimizations haven't kicked in, or where upgrading to a larger instance would be needed

Changes already applied in monitoring dashboards